### PR TITLE
Use null values for proper parsing of optional commands

### DIFF
--- a/src/main/java/seedu/duke/logic/commands/AddExerciseBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddExerciseBankCommand.java
@@ -28,13 +28,13 @@ public class AddExerciseBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (exercise.getCalories() <= 0) {
-            logger.log(Level.FINE, "Exercise calorie is invalid");
+            logger.log(Level.WARNING, "Exercise calorie is invalid");
             return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
         }
         assert exercise.getCalories() > 0 : "Exercise calorie is valid";
         try {
             super.exerciseBank.addItem(this.exercise);
-            logger.log(Level.FINE, "Exercise is successfully added to exercise bank");
+            logger.log(Level.WARNING, "Exercise is successfully added to exercise bank");
             return new CommandResult(String.format(MESSAGE_SUCCESS, this.exercise));
         } catch (DuplicateItemInBankException e) {
             return new CommandResult(String.format(

--- a/src/main/java/seedu/duke/logic/commands/AddExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddExerciseCommand.java
@@ -24,22 +24,20 @@ public class AddExerciseCommand extends Command {
     private static Logger logger = Logger.getLogger(AddExerciseCommand.class.getName());
 
     private final String description;
-    private int calories;
+    private Integer calories;
     private final LocalDate date;
-    private final boolean isCaloriesFromBank;
 
-    public AddExerciseCommand(String description, int calories, LocalDate date, boolean isCaloriesFromBank) {
+    public AddExerciseCommand(String description, Integer calories, LocalDate date) {
         this.description = description;
         this.calories = calories;
         this.date = date;
-        this.isCaloriesFromBank = isCaloriesFromBank;
     }
 
     @Override
     public CommandResult execute() {
         final Exercise exercise;
 
-        if (isCaloriesFromBank) {
+        if (calories == null) {
             try {
                 this.calories = super.exerciseBank.findCalorie(this.description);
             } catch (ItemNotFoundInBankException e) {
@@ -48,7 +46,7 @@ public class AddExerciseCommand extends Command {
             }
         } else {
             if (this.calories <= 0) {
-                logger.log(Level.FINE, "Exercise calorie is invalid");
+                logger.log(Level.WARNING, "Exercise calorie is invalid");
                 return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
             }
 
@@ -57,7 +55,7 @@ public class AddExerciseCommand extends Command {
         exercise = new Exercise(this.description, this.calories, this.date);
         assert exercise.getCalories() > 0 : "Exercise calorie is valid";
         super.exerciseItems.addItem(exercise);
-        logger.log(Level.FINE, "Exercise is successfully added");
+        logger.log(Level.WARNING, "Exercise is successfully added");
         return new CommandResult(String.format(MESSAGE_SUCCESS, exercise.toStringWithDate()));
     }
 }

--- a/src/main/java/seedu/duke/logic/commands/AddFoodBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddFoodBankCommand.java
@@ -29,13 +29,13 @@ public class AddFoodBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (food.getCalories() < 0) {
-            logger.log(Level.FINE, "Food calorie is invalid");
+            logger.log(Level.WARNING, "Food calorie is invalid");
             return new CommandResult(CommandMessages.MESSAGE_INVALID_FOOD_CALORIES);
         }
         assert food.getCalories() >= 0 : "Food calorie is valid";
         try {
             super.foodBank.addItem(this.food);
-            logger.log(Level.FINE, "Food is successfully added to food bank");
+            logger.log(Level.WARNING, "Food is successfully added to food bank");
             return new CommandResult(String.format(MESSAGE_SUCCESS, this.food.toStringWithoutDateAndTime()));
         } catch (DuplicateItemInBankException e) {
             return new CommandResult(String.format(CommandMessages.MESSAGE_FOOD_ALREADY_EXISTS_IN_BANK,

--- a/src/main/java/seedu/duke/logic/commands/AddFoodCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddFoodCommand.java
@@ -23,22 +23,21 @@ public class AddFoodCommand extends Command {
 
     private Logger logger = Logger.getLogger(AddFoodCommand.class.getName());
     private final String description;
-    private int calories;
+    private Integer calories;
     private final LocalDateTime dateTime;
-    private final boolean isCaloriesFromBank;
 
-    public AddFoodCommand(String description, int calories, LocalDateTime dateTime, boolean isCaloriesFromBank) {
+
+    public AddFoodCommand(String description, Integer calories, LocalDateTime dateTime) {
         this.description = description;
         this.calories = calories;
         this.dateTime = dateTime;
-        this.isCaloriesFromBank = isCaloriesFromBank;
     }
 
     @Override
     public CommandResult execute() {
         final Food food;
 
-        if (isCaloriesFromBank) {
+        if (calories == null) {
             try {
                 this.calories = super.foodBank.findCalorie(this.description);
             } catch (ItemNotFoundInBankException e) {
@@ -47,7 +46,7 @@ public class AddFoodCommand extends Command {
             }
         } else {
             if (this.calories < 0) {
-                logger.log(Level.FINE, "Detected negative food calorie");
+                logger.log(Level.WARNING, "Detected negative food calorie");
                 return new CommandResult(CommandMessages.MESSAGE_INVALID_FOOD_CALORIES);
             }
         }
@@ -55,7 +54,7 @@ public class AddFoodCommand extends Command {
         food = new Food(this.description, this.calories, this.dateTime);
         super.foodItems.addItem(food);
         assert foodItems.getSize() > 0 : "The size of the food list should at least larger than 0";
-        logger.log(Level.FINE, "New food item has been added to the food list");
+        logger.log(Level.WARNING, "New food item has been added to the food list");
         return new CommandResult(String.format(MESSAGE_SUCCESS, food.toStringWithDate()));
 
     }

--- a/src/main/java/seedu/duke/logic/commands/AddFutureExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddFutureExerciseCommand.java
@@ -20,23 +20,21 @@ public class AddFutureExerciseCommand extends Command {
 
 
     private final String description;
-    private int calories;
+    private Integer calories;
     private final LocalDate date;
-    private boolean isCaloriesFromBank;
 
 
-    public AddFutureExerciseCommand(String description, int calories, LocalDate date, boolean isCaloriesFromBank) {
+    public AddFutureExerciseCommand(String description, Integer calories, LocalDate date) {
         this.description = description;
         this.calories = calories;
         this.date = date;
-        this.isCaloriesFromBank = isCaloriesFromBank;
     }
 
     @Override
     public CommandResult execute() {
         final Exercise exercise;
 
-        if (isCaloriesFromBank) {
+        if (calories == null) {
             try {
                 this.calories = super.exerciseBank.findCalorie(this.description);
             } catch (ItemNotFoundInBankException e) {
@@ -45,7 +43,7 @@ public class AddFutureExerciseCommand extends Command {
             }
         } else {
             if (this.calories <= 0) {
-                logger.log(Level.FINE, "Exercise calorie is invalid");
+                logger.log(Level.WARNING, "Exercise calorie is invalid");
                 return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
             }
         }
@@ -53,7 +51,7 @@ public class AddFutureExerciseCommand extends Command {
         exercise = new Exercise(this.description, this.calories, this.date);
         assert exercise.getCalories() > 0 : "Exercise calorie is valid";
         super.futureExerciseItems.addItem(exercise);
-        logger.log(Level.FINE, "Exercise is successfully added");
+        logger.log(Level.WARNING, "Exercise is successfully added");
         return new CommandResult(String.format(MESSAGE_SUCCESS, exercise.toStringWithDate()));
     }
 }

--- a/src/main/java/seedu/duke/logic/commands/AddRecurringExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/AddRecurringExerciseCommand.java
@@ -28,34 +28,31 @@ public class AddRecurringExerciseCommand extends Command {
     };
 
     private final String description;
-    private int calories;
-    private boolean isCaloriesFromBank;
+    private Integer calories;
     private final LocalDate startDate;
     private final LocalDate endDate;
     private final ArrayList<Integer> dayOfTheWeek;
 
     private static Logger logger = Logger.getLogger(AddRecurringExerciseCommand.class.getName());
 
-    public AddRecurringExerciseCommand(String description, int calories, LocalDate startDate,
-                                       LocalDate endDate, ArrayList<Integer> dayOfTheWeek,
-                                       boolean isCaloriesFromBank) {
+    public AddRecurringExerciseCommand(String description, Integer calories, LocalDate startDate,
+                                       LocalDate endDate, ArrayList<Integer> dayOfTheWeek) {
         this.description = description;
         this.calories = calories;
         this.startDate = startDate;
         this.endDate = endDate;
         this.dayOfTheWeek = dayOfTheWeek;
-        this.isCaloriesFromBank = isCaloriesFromBank;
     }
 
     @Override
     public CommandResult execute() {
         if (this.startDate.isAfter(this.endDate)) {
-            logger.log(Level.FINE, "Start date is after end date");
+            logger.log(Level.WARNING, "Start date is after end date");
             return new CommandResult(String.format(MESSAGE_INVALID_DATES,
                     this.startDate.format(CommandMessages.DATE_FORMATTER),
                     this.endDate.format(CommandMessages.DATE_FORMATTER)));
         }
-        if (isCaloriesFromBank) {
+        if (calories == null) {
             try {
                 this.calories = super.exerciseBank.findCalorie(this.description);
             } catch (ItemNotFoundInBankException e) {
@@ -64,20 +61,20 @@ public class AddRecurringExerciseCommand extends Command {
             }
         } else {
             if (this.calories <= 0) {
-                logger.log(Level.FINE, "Exercise calorie is invalid");
+                logger.log(Level.WARNING, "Exercise calorie is invalid");
                 return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
             }
         }
         assert this.endDate.isAfter(this.startDate) : "End date is after start date";
         if (!this.startDate.isAfter(LocalDate.now())) {
-            logger.log(Level.FINE, "Recurring exercises are for future only");
+            logger.log(Level.WARNING, "Recurring exercises are for future only");
             return new CommandResult(String.format(MESSAGE_INVALID_FUTURE_DATES,
                     this.startDate.format(CommandMessages.DATE_FORMATTER),
                     this.endDate.format(CommandMessages.DATE_FORMATTER)));
         }
         assert this.startDate.isAfter(LocalDate.now()) : "Start and end dates are in the future";
         if (this.calories <= 0) {
-            logger.log(Level.FINE, "Exercise calorie is invalid");
+            logger.log(Level.WARNING, "Exercise calorie is invalid");
             return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
         }
         assert this.calories > 0 : "Exercise calorie is valid";
@@ -90,7 +87,7 @@ public class AddRecurringExerciseCommand extends Command {
                     this.endDate.format(CommandMessages.DATE_FORMATTER)));
         }
 
-        logger.log(Level.FINE, "Recurring exercise is successfully added");
+        logger.log(Level.WARNING, "Recurring exercise is successfully added");
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/duke/logic/commands/Command.java
+++ b/src/main/java/seedu/duke/logic/commands/Command.java
@@ -7,7 +7,6 @@ import seedu.duke.data.item.exercise.FutureExerciseList;
 import seedu.duke.data.item.food.FoodList;
 import seedu.duke.data.profile.Profile;
 
-import java.time.LocalDate;
 
 /**
  * Abstract class used to represent executable Commands.
@@ -41,13 +40,7 @@ public abstract class Command {
     public static final String COMMAND_WORD_BMI = "bmi";
     public static final String COMMAND_WORD_PROFILE = "profile";
     public static final String COMMAND_WORD_DELETE_ALL = "all";
-    public static final double NULL_DOUBLE = Double.MIN_VALUE;
-    public static final int NULL_INT = Integer.MIN_VALUE;
     public static final char NULL_CHAR = '|';
-    public static final int NULL_CALORIES = -1;
-    public static final String NULL_STRING = "";
-    public static final LocalDate NULL_DATE = LocalDate.MIN;
-
 
     protected Profile profile;
     protected ExerciseList exerciseItems;

--- a/src/main/java/seedu/duke/logic/commands/DeleteExerciseBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/DeleteExerciseBankCommand.java
@@ -21,31 +21,30 @@ public class DeleteExerciseBankCommand extends Command {
 
     private static Logger logger = Logger.getLogger(DeleteExerciseBankCommand.class.getName());
 
-    private final int itemIndex;
+    private int itemIndex;
     private boolean isClear = false;
 
     public DeleteExerciseBankCommand(int itemIndex) {
-        this.itemIndex = itemIndex; //-2
+        this.itemIndex = itemIndex;
     }
 
     public DeleteExerciseBankCommand(boolean isClear) {
-        this.itemIndex = -1;
         this.isClear = isClear;
     }
 
     @Override
     public CommandResult execute() {
         if (this.isClear) {
-            logger.log(Level.FINE, "Clearing exercise bank");
+            logger.log(Level.WARNING, "Clearing exercise bank");
             super.exerciseBank.clearList();
             return new CommandResult(MESSAGE_EXERCISE_CLEAR);
         }
         assert this.itemIndex > 0 : "Deleting an item only";
         if (super.exerciseBank.getSize() == 0) {
-            logger.log(Level.FINE, "Exercise bank is empty.");
+            logger.log(Level.WARNING, "Exercise bank is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_EXERCISE_BANK);
         }
-        logger.log(Level.FINE, "Trying to delete item now");
+        logger.log(Level.WARNING, "Trying to delete item now");
         try {
             Exercise deletedExercise;
             deletedExercise = (Exercise) super.exerciseBank.deleteItem(this.itemIndex);
@@ -53,7 +52,7 @@ public class DeleteExerciseBankCommand extends Command {
                     deletedExercise.toStringWithoutDateAndTime(),
                     super.exerciseBank.getSize()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid exercise item index.");
+            logger.log(Level.WARNING, "Detected invalid exercise item index.");
             if (super.exerciseBank.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/DeleteExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/DeleteExerciseCommand.java
@@ -21,8 +21,8 @@ public class DeleteExerciseCommand extends Command {
     };
 
 
-    private final int itemIndex;
-    private final LocalDate date;
+    private int itemIndex;
+    private LocalDate date;
     private boolean isClear = false;
 
     public DeleteExerciseCommand(int itemIndex, LocalDate date) {
@@ -32,23 +32,21 @@ public class DeleteExerciseCommand extends Command {
 
     public DeleteExerciseCommand(boolean isClear) {
         this.itemIndex = -1;
-        this.isClear = isClear;
-        this.date = LocalDate.now();
     }
 
     @Override
     public CommandResult execute() {
         if (this.isClear) {
-            logger.log(Level.FINE, "Clearing exercise list");
+            logger.log(Level.WARNING, "Clearing exercise list");
             super.exerciseItems.clearList();
             return new CommandResult(MESSAGE_EXERCISE_CLEAR);
         }
         assert this.itemIndex > 0 : "Deleting an item only";
         if (super.exerciseItems.getSize() == 0) {
-            logger.log(Level.FINE, "Exercise list is empty.");
+            logger.log(Level.WARNING, "Exercise list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_EXERCISE_LIST);
         }
-        logger.log(Level.FINE, "Trying to delete item now");
+        logger.log(Level.WARNING, "Trying to delete item now");
         try {
             Exercise deletedExercise;
             deletedExercise = super.exerciseItems.deleteItem(this.itemIndex, this.date);

--- a/src/main/java/seedu/duke/logic/commands/DeleteFoodBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/DeleteFoodBankCommand.java
@@ -21,7 +21,7 @@ public class DeleteFoodBankCommand extends Command {
 
     private static Logger logger = Logger.getLogger(DeleteFoodBankCommand.class.getName());
 
-    private final int itemIndex;
+    private int itemIndex;
     private boolean isClear = false;
 
     public DeleteFoodBankCommand(int itemIndex) {
@@ -29,23 +29,22 @@ public class DeleteFoodBankCommand extends Command {
     }
 
     public DeleteFoodBankCommand(boolean isClear) {
-        this.itemIndex = -1;
         this.isClear = isClear;
     }
 
     @Override
     public CommandResult execute() {
         if (this.isClear) {
-            logger.log(Level.FINE, "Clearing food bank");
+            logger.log(Level.WARNING, "Clearing food bank");
             super.foodBank.clearList();
             return new CommandResult(MESSAGE_FOOD_CLEAR);
         }
         assert this.itemIndex > 0 : "Deleting an item only";
         if (super.foodBank.getSize() == 0) {
-            logger.log(Level.FINE, "food bank is empty.");
+            logger.log(Level.WARNING, "food bank is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FOOD_BANK);
         }
-        logger.log(Level.FINE, "Trying to delete item now");
+        logger.log(Level.WARNING, "Trying to delete item now");
         try {
             Food deletedFood;
             deletedFood = (Food) super.foodBank.deleteItem(this.itemIndex);
@@ -53,7 +52,7 @@ public class DeleteFoodBankCommand extends Command {
                     deletedFood.toStringWithoutDateAndTime(),
                     super.foodBank.getSize()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid food item index.");
+            logger.log(Level.WARNING, "Detected invalid food item index.");
             if (super.foodBank.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/DeleteFoodCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/DeleteFoodCommand.java
@@ -21,9 +21,9 @@ public class DeleteFoodCommand extends Command {
     };
 
 
-    private final int itemIndex;
-    private final LocalDate date;
-    private final LocalTime time;
+    private int itemIndex;
+    private LocalDate date;
+    private LocalTime time;
     private boolean isClear = false;
 
     private static final Logger logger = Logger.getLogger(DeleteFoodCommand.class.getName());
@@ -35,33 +35,30 @@ public class DeleteFoodCommand extends Command {
     }
 
     public DeleteFoodCommand(boolean isClear) {
-        this.itemIndex = -1;
         this.isClear = isClear;
-        this.date = LocalDate.now();
-        this.time = LocalTime.now();
     }
 
     @Override
     public CommandResult execute() {
         if (this.isClear) {
-            logger.log(Level.FINE, "Clearing food list");
+            logger.log(Level.WARNING, "Clearing food list");
             super.foodItems.clearList();
             assert foodItems.getSize() == 0 : "The size of the food list should be 0 after clear";
             return new CommandResult(MESSAGE_FOOD_CLEAR);
         }
         assert this.itemIndex > 0 : "Deleting an object only";
         if (super.foodItems.getSize() == 0) {
-            logger.log(Level.FINE, "Food list is empty.");
+            logger.log(Level.WARNING, "Food list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FOOD_LIST);
         }
-        logger.log(Level.FINE, "Trying to delete item now");
+        logger.log(Level.WARNING, "Trying to delete item now");
         try {
             Food deletedFood;
             deletedFood = super.foodItems.deleteItem(this.itemIndex, this.date, this.time);
             return new CommandResult(String.format(MESSAGE_SUCCESS,
                     deletedFood.toStringWithDate()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid food item index.");
+            logger.log(Level.WARNING, "Detected invalid food item index.");
             return new CommandResult(String.format(CommandMessages.MESSAGE_FOOD_NOT_FOUND,
                     this.itemIndex + 1,
                     this.date.format(CommandMessages.DATE_FORMATTER),

--- a/src/main/java/seedu/duke/logic/commands/DeleteFutureExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/DeleteFutureExerciseCommand.java
@@ -21,7 +21,7 @@ public class DeleteFutureExerciseCommand extends Command {
 
     private static Logger logger = Logger.getLogger(DeleteFutureExerciseCommand.class.getName());
 
-    private final int itemIndex;
+    private int itemIndex;
     private boolean isClear = false;
 
     public DeleteFutureExerciseCommand(int itemIndex) {
@@ -29,30 +29,29 @@ public class DeleteFutureExerciseCommand extends Command {
     }
 
     public DeleteFutureExerciseCommand(boolean isClear) {
-        this.itemIndex = -1;
         this.isClear = isClear;
     }
 
     @Override
     public CommandResult execute() {
         if (this.isClear) {
-            logger.log(Level.FINE, "Clearing future exercise list");
+            logger.log(Level.WARNING, "Clearing future exercise list");
             super.futureExerciseItems.clearList();
             return new CommandResult(MESSAGE_FUTURE_EXERCISE_CLEAR);
         }
         assert this.itemIndex > 0 : "Deleting an item only";
         if (super.futureExerciseItems.getSize() == 0) {
-            logger.log(Level.FINE, "Future exercise list is empty.");
+            logger.log(Level.WARNING, "Future exercise list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FUTURE_EXERCISE_LIST);
         }
-        logger.log(Level.FINE, "Trying to delete item now");
+        logger.log(Level.WARNING, "Trying to delete item now");
         try {
             Exercise deletedExercise;
             deletedExercise = super.futureExerciseItems.deleteItem(this.itemIndex);
             return new CommandResult(String.format(MESSAGE_SUCCESS, deletedExercise.toStringWithDate(),
                     super.futureExerciseItems.getSize()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid exercise item index.");
+            logger.log(Level.WARNING, "Detected invalid exercise item index.");
             if (super.futureExerciseItems.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/EditExerciseBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/EditExerciseBankCommand.java
@@ -25,9 +25,9 @@ public class EditExerciseBankCommand extends Command {
 
     private final int itemIndex;
     private final String newName;
-    private final int newCalories;
+    private final Integer newCalories;
 
-    public EditExerciseBankCommand(int itemIndex, String newName, int newCalories) {
+    public EditExerciseBankCommand(int itemIndex, String newName, Integer newCalories) {
         this.itemIndex = itemIndex;
         this.newName = newName;
         this.newCalories = newCalories;
@@ -36,18 +36,18 @@ public class EditExerciseBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.exerciseBank.getSize() == 0) {
-            logger.log(Level.FINE, "Exercise bank list is empty.");
+            logger.log(Level.WARNING, "Exercise bank list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_EXERCISE_BANK);
         }
         try {
             Item item = super.exerciseBank.getItem(this.itemIndex);
-            if (!this.newName.equals(NULL_STRING)) {
+            if (this.newName != null) {
                 super.exerciseBank.checkNoDuplicateItemName(this.newName);
                 item.setName(this.newName);
             }
-            if (this.newCalories != NULL_CALORIES) {
+            if (this.newCalories != null) {
                 if (this.newCalories <= 0) {
-                    logger.log(Level.FINE, "Exercise calorie is invalid");
+                    logger.log(Level.WARNING, "Exercise calorie is invalid");
                     return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
                 }
                 item.setCalories(this.newCalories);
@@ -55,7 +55,7 @@ public class EditExerciseBankCommand extends Command {
             return new CommandResult(String.format(MESSAGE_SUCCESS, this.itemIndex + 1,
                     super.exerciseBank.getItem(this.itemIndex).toStringWithoutDateAndTime()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid exercise bank item index.");
+            logger.log(Level.WARNING, "Detected invalid exercise bank item index.");
             if (super.exerciseBank.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/EditFoodBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/EditFoodBankCommand.java
@@ -23,9 +23,9 @@ public class EditFoodBankCommand extends Command {
 
     private final int itemIndex;
     private final String newName;
-    private final int newCalories;
+    private final Integer newCalories;
 
-    public EditFoodBankCommand(int itemIndex, String newName, int newCalories) {
+    public EditFoodBankCommand(int itemIndex, String newName, Integer newCalories) {
         this.itemIndex = itemIndex;
         this.newName = newName;
         this.newCalories = newCalories;
@@ -34,18 +34,18 @@ public class EditFoodBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.foodBank.getSize() == 0) {
-            logger.log(Level.FINE, "Food bank list is empty.");
+            logger.log(Level.WARNING, "Food bank list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FOOD_BANK);
         }
         try {
             Item item = super.foodBank.getItem(this.itemIndex);
-            if (!this.newName.equals(NULL_STRING)) {
+            if (this.newName != null) {
                 super.foodBank.checkNoDuplicateItemName(this.newName);
                 item.setName(this.newName);
             }
-            if (this.newCalories != NULL_CALORIES) {
+            if (this.newCalories != null) {
                 if (this.newCalories < 0) {
-                    logger.log(Level.FINE, "Detected negative food calorie");
+                    logger.log(Level.WARNING, "Detected negative food calorie");
                     return new CommandResult(CommandMessages.MESSAGE_INVALID_FOOD_CALORIES);
                 }
                 item.setCalories(this.newCalories);
@@ -53,7 +53,7 @@ public class EditFoodBankCommand extends Command {
             return new CommandResult(String.format(MESSAGE_SUCCESS, this.itemIndex + 1,
                     item.toStringWithoutDateAndTime()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid food bank item index.");
+            logger.log(Level.WARNING, "Detected invalid food bank item index.");
             if (super.foodBank.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/EditFutureExerciseCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/EditFutureExerciseCommand.java
@@ -26,10 +26,10 @@ public class EditFutureExerciseCommand extends Command {
 
     private final int itemIndex;
     private final String newName;
-    private final int newCalories;
+    private final Integer newCalories;
     private final LocalDate newDate;
 
-    public EditFutureExerciseCommand(int itemIndex, String newName, int newCalories, LocalDate newDate) {
+    public EditFutureExerciseCommand(int itemIndex, String newName, Integer newCalories, LocalDate newDate) {
         this.itemIndex = itemIndex;
         this.newName = newName;
         this.newCalories = newCalories;
@@ -39,22 +39,22 @@ public class EditFutureExerciseCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.futureExerciseItems.getSize() == 0) {
-            logger.log(Level.FINE, "Future exercise list is empty.");
+            logger.log(Level.WARNING, "Future exercise list is empty.");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FUTURE_EXERCISE_LIST);
         }
         try {
             Item item = super.futureExerciseItems.getItem(this.itemIndex);
-            if (!this.newName.equals(NULL_STRING)) {
+            if (this.newName != null) {
                 item.setName(this.newName);
             }
-            if (this.newCalories != NULL_CALORIES) {
+            if (this.newCalories != null) {
                 if (this.newCalories <= 0) {
-                    logger.log(Level.FINE, "Exercise calorie is invalid");
+                    logger.log(Level.WARNING, "Exercise calorie is invalid");
                     return new CommandResult(CommandMessages.MESSAGE_INVALID_EXERCISE_CALORIES);
                 }
                 item.setCalories(this.newCalories);
             }
-            if (!this.newDate.equals(NULL_DATE)) {
+            if (!this.newDate.equals(null)) {
                 if (!this.newDate.isAfter(LocalDate.now())) {
                     return new CommandResult(MESSAGE_INVALID_DATE);
                 }
@@ -64,7 +64,7 @@ public class EditFutureExerciseCommand extends Command {
             return new CommandResult(String.format(MESSAGE_SUCCESS, this.itemIndex + 1,
                     item.toStringWithDate()));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected invalid exercise item index.");
+            logger.log(Level.WARNING, "Detected invalid exercise item index.");
             if (super.futureExerciseItems.getSize() == 1) {
                 return new CommandResult(CommandMessages.MESSAGE_ONLY_ONE_IN_LIST);
             }

--- a/src/main/java/seedu/duke/logic/commands/ProfileUpdateCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ProfileUpdateCommand.java
@@ -34,15 +34,18 @@ public class ProfileUpdateCommand extends Command {
     private ActivityFactor activityFactor;
     private Gender gender;
 
-    public ProfileUpdateCommand(String name, double height, double weight, int calorieGoal, int age,
-                                int activityFactor, char gender) {
-        this.name = new Name(name);
-        this.height = new Height(height);
-        this.weight = new Weight(weight);
-        this.calorieGoal = new CalorieGoal(calorieGoal);
-        this.gender = new Gender(gender);
-        this.age = new Age(age);
-        this.activityFactor = new ActivityFactor(activityFactor);
+
+
+    public ProfileUpdateCommand(String name, Double height, Double weight, Integer calorieGoal, Integer age,
+                                Integer activityFactor, Character gender) {
+        this.name = name == null ? null : new Name(name);
+        this.height = height == null ? null: new Height(height);
+        this.weight = weight == null ? null : new Weight(weight);
+        this.calorieGoal = calorieGoal == null ? null : new CalorieGoal(calorieGoal);
+        this.gender = gender == NULL_CHAR ? null : new Gender(gender);
+        this.age = age == null ? null : new Age(age);
+        this.activityFactor = activityFactor == null ? null : new ActivityFactor(activityFactor);
+
     }
 
     private void checkIfCommandShouldExecute() throws InvalidCharacteristicException {
@@ -69,15 +72,15 @@ public class ProfileUpdateCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            this.name = name.getName().equals(NULL_STRING) ? super.profile.getProfileName() : name;
-            this.height = height.getHeight() == NULL_DOUBLE ? super.profile.getProfileHeight() : height;
-            this.weight = weight.getWeight() == NULL_DOUBLE ? super.profile.getProfileWeight() : weight;
-            this.gender = gender.getGender() == NULL_CHAR ? super.profile.getProfileGender() : gender;
-            this.age = age.getAge() == NULL_INT ? super.profile.getProfileAge() : age;
-            this.calorieGoal = calorieGoal.getCalorieGoal() == NULL_INT
+            this.name = name == null  ? super.profile.getProfileName() : name;
+            this.height = height == null ? super.profile.getProfileHeight() : height;
+            this.weight = weight == null ? super.profile.getProfileWeight() : weight;
+            this.gender = gender == null ? super.profile.getProfileGender() : gender;
+            this.age = age == null ? super.profile.getProfileAge() : age;
+            this.calorieGoal = calorieGoal == null
                     ? super.profile.getProfileCalorieGoal()
                     : calorieGoal;
-            this.activityFactor = activityFactor.getActivityFactor() == NULL_INT
+            this.activityFactor = activityFactor == null
                     ? super.profile.getProfileActivityFactor()
                     : activityFactor;
 

--- a/src/main/java/seedu/duke/logic/commands/ProfileUpdateCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ProfileUpdateCommand.java
@@ -39,7 +39,7 @@ public class ProfileUpdateCommand extends Command {
     public ProfileUpdateCommand(String name, Double height, Double weight, Integer calorieGoal, Integer age,
                                 Integer activityFactor, Character gender) {
         this.name = name == null ? null : new Name(name);
-        this.height = height == null ? null: new Height(height);
+        this.height = height == null ? null : new Height(height);
         this.weight = weight == null ? null : new Weight(weight);
         this.calorieGoal = calorieGoal == null ? null : new CalorieGoal(calorieGoal);
         this.gender = gender == NULL_CHAR ? null : new Gender(gender);

--- a/src/main/java/seedu/duke/logic/commands/ViewExerciseBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ViewExerciseBankCommand.java
@@ -15,7 +15,7 @@ public class ViewExerciseBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.exerciseBank.getSize() == 0) {
-            logger.log(Level.FINE, "Exercise bank is empty");
+            logger.log(Level.WARNING, "Exercise bank is empty");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_EXERCISE_BANK);
         }
         assert exerciseBank.getSize() > 0 : "Exercise bank is not empty";

--- a/src/main/java/seedu/duke/logic/commands/ViewExerciseListCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ViewExerciseListCommand.java
@@ -16,7 +16,7 @@ public class ViewExerciseListCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.exerciseItems.getSize() == 0) {
-            logger.log(Level.FINE, "Exercise list is empty");
+            logger.log(Level.WARNING, "Exercise list is empty");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_EXERCISE_LIST);
         }
         assert exerciseItems.getSize() > 0 : "Exercise list is not empty";

--- a/src/main/java/seedu/duke/logic/commands/ViewFoodBankCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ViewFoodBankCommand.java
@@ -15,7 +15,7 @@ public class ViewFoodBankCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.foodBank.getSize() == 0) {
-            logger.log(Level.FINE, "Food bank is empty");
+            logger.log(Level.WARNING, "Food bank is empty");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FOOD_BANK);
         }
         assert foodBank.getSize() > 0 : "Food bank is not empty";

--- a/src/main/java/seedu/duke/logic/commands/ViewFutureExerciseListCommand.java
+++ b/src/main/java/seedu/duke/logic/commands/ViewFutureExerciseListCommand.java
@@ -15,7 +15,7 @@ public class ViewFutureExerciseListCommand extends Command {
     @Override
     public CommandResult execute() {
         if (super.futureExerciseItems.getSize() == 0) {
-            logger.log(Level.FINE, "Future exercise list is empty");
+            logger.log(Level.WARNING, "Future exercise list is empty");
             return new CommandResult(CommandMessages.MESSAGE_EMPTY_FUTURE_EXERCISE_LIST);
         }
         assert futureExerciseItems.getSize() > 0 : "Future exercise list is not empty";

--- a/src/main/java/seedu/duke/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/duke/logic/parser/AddCommandParser.java
@@ -54,19 +54,12 @@ public class AddCommandParser implements Parser {
     protected Command parseAddToItems(String params, String itemTypePrefix) throws ItemNotSpecifiedException {
         try {
             final String description = ParserUtils.extractItemDescription(params, itemTypePrefix);
-            int calories = Command.NULL_CALORIES;
-            boolean isCaloriesFromBank = false;
-            try {
-                calories = ParserUtils.extractItemCalories(params, true);
-            } catch (ParamMissingException e) {
-                isCaloriesFromBank = true; //signals to Command class to check for calories from the item bank
-                logger.log(Level.FINE, "No calories detected, to try checking from item bank");
-            }
-
+            Integer calories = null;
+            calories = ParserUtils.extractItemCalories(params, false);
             switch (itemTypePrefix) {
             case Command.COMMAND_PREFIX_EXERCISE:
                 final LocalDate date = ParserUtils.extractDate(params, false);
-                logger.log(Level.FINE, String.format("date detected is: %s", date));
+                logger.log(Level.WARNING, String.format("date detected is: %s", date));
                 if (ParserUtils.hasExtraDelimiters(params, AddExerciseCommand.EXPECTED_PREFIXES)) {
                     return new InvalidCommand(ParserMessages.MESSAGE_ERROR_TOO_MANY_DELIMITERS);
                 } else if (ParserUtils.isSevenDaysBeforeToday(date)) {
@@ -75,13 +68,13 @@ public class AddCommandParser implements Parser {
                             LocalDate.now().format(DATE_FORMAT)));
                 }
                 if (ParserUtils.isFutureDate(date)) {
-                    logger.log(Level.FINE, String.format("adding to future list"));
-                    return new AddFutureExerciseCommand(description, calories, date, isCaloriesFromBank);
+                    logger.log(Level.WARNING, String.format("adding to future list"));
+                    return new AddFutureExerciseCommand(description, calories, date);
                 }
-                return new AddExerciseCommand(description, calories, date, isCaloriesFromBank);
+                return new AddExerciseCommand(description, calories, date);
             case Command.COMMAND_PREFIX_FOOD:
                 final LocalDateTime dateTime = ParserUtils.extractDateTime(params);
-                logger.log(Level.FINE, String.format("dateTime detected is: %s", dateTime));
+                logger.log(Level.WARNING, String.format("dateTime detected is: %s", dateTime));
                 if (ParserUtils.hasExtraDelimiters(params, AddFoodCommand.EXPECTED_PREFIXES)) {
                     return new InvalidCommand(ParserMessages.MESSAGE_ERROR_TOO_MANY_DELIMITERS);
                 } else if (ParserUtils.isSevenDaysBeforeToday(dateTime.toLocalDate())) {
@@ -89,7 +82,7 @@ public class AddCommandParser implements Parser {
                             LocalDate.now().minusDays(7).format(DATE_FORMAT),
                             LocalDate.now().format(DATE_FORMAT)));
                 }
-                return new AddFoodCommand(description, calories, dateTime, isCaloriesFromBank);
+                return new AddFoodCommand(description, calories, dateTime);
             case Command.COMMAND_PREFIX_RECURRING:
                 final LocalDate startDate = ParserUtils.extractStartDate(params);
                 final LocalDate endDate = ParserUtils.extractEndDate(params);
@@ -98,7 +91,7 @@ public class AddCommandParser implements Parser {
                     return new InvalidCommand(ParserMessages.MESSAGE_ERROR_TOO_MANY_DELIMITERS);
                 }
                 return new AddRecurringExerciseCommand(description, calories,
-                        startDate, endDate, dayOfTheWeek, isCaloriesFromBank);
+                        startDate, endDate, dayOfTheWeek);
             default:
                 throw new ItemNotSpecifiedException();
             }

--- a/src/main/java/seedu/duke/logic/parser/BmiParser.java
+++ b/src/main/java/seedu/duke/logic/parser/BmiParser.java
@@ -33,7 +33,7 @@ public class BmiParser implements Parser {
                 return new InvalidCommand(e.getMessage());
             }
         } else {
-            logger.log(Level.FINE, "Detected invalid input parameters for BMI calculation.");
+            logger.log(Level.WARNING, "Detected invalid input parameters for BMI calculation.");
             return new InvalidCommand(CalculateBmiCommand.MESSAGE_INVALID_COMMAND_FORMAT);
         }
     }

--- a/src/main/java/seedu/duke/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/duke/logic/parser/DeleteCommandParser.java
@@ -61,21 +61,21 @@ public class DeleteCommandParser implements Parser {
         try {
             final int itemIndex = ParserUtils.extractItemIndex(params, itemTypePrefix);
             final LocalDate date = ParserUtils.extractDate(params, true);
-            logger.log(Level.FINE, String.format("date detected is: %s", date));
+            logger.log(Level.WARNING, String.format("date detected is: %s", date));
 
             switch (itemTypePrefix) {
             case Command.COMMAND_PREFIX_EXERCISE:
                 if (ParserUtils.hasExtraDelimiters(params, DeleteExerciseCommand.EXPECTED_PREFIXES)) {
                     return new InvalidCommand(ParserMessages.MESSAGE_ERROR_TOO_MANY_DELIMITERS);
                 }
-                logger.log(Level.FINE, String.format("deleting exercise item %s from %s", itemIndex, date));
+                logger.log(Level.WARNING, String.format("deleting exercise item %s from %s", itemIndex, date));
                 return new DeleteExerciseCommand(itemIndex, date);
             case Command.COMMAND_PREFIX_FOOD:
                 if (ParserUtils.hasExtraDelimiters(params, DeleteFoodCommand.EXPECTED_PREFIXES)) {
                     return new InvalidCommand(ParserMessages.MESSAGE_ERROR_TOO_MANY_DELIMITERS);
                 }
                 final LocalTime time = ParserUtils.extractTime(params, true);
-                logger.log(Level.FINE, String.format("deleting food item %s from %s %s", itemIndex, date, time));
+                logger.log(Level.WARNING, String.format("deleting food item %s from %s %s", itemIndex, date, time));
                 return new DeleteFoodCommand(itemIndex, date, time);
             default:
                 throw new ItemNotSpecifiedException();

--- a/src/main/java/seedu/duke/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/duke/logic/parser/EditCommandParser.java
@@ -50,7 +50,7 @@ public class EditCommandParser implements Parser {
                 return new InvalidCommand(CommandMessages.MESSAGE_EDIT_BANK_NEED_DETAILS);
             }
             final String description = ParserUtils.extractName(params);
-            final int calories = ParserUtils.extractItemCalories(params, false);
+            final Integer calories = ParserUtils.extractItemCalories(params, false);
             switch (itemTypePrefix) {
             case Command.COMMAND_PREFIX_EXERCISE_BANK:
                 if (ParserUtils.hasExtraDelimiters(params, EditExerciseBankCommand.EXPECTED_PREFIXES)) {
@@ -80,10 +80,10 @@ public class EditCommandParser implements Parser {
             }
 
             final String description = ParserUtils.extractName(params);
-            final int calories = ParserUtils.extractItemCalories(params, false);
+            final Integer calories = ParserUtils.extractItemCalories(params, false);
             final LocalDate date = ParserUtils.hasRequiredParams(params, Command.COMMAND_PREFIX_DATE)
                     ? ParserUtils.extractDate(params, false)
-                    : Command.NULL_DATE;
+                    : null;
             switch (itemTypePrefix) {
             case Command.COMMAND_PREFIX_UPCOMING_EXERCISE:
                 if (ParserUtils.hasExtraDelimiters(params, EditFutureExerciseCommand.EXPECTED_PREFIXES)) {

--- a/src/main/java/seedu/duke/logic/parser/ParserUtils.java
+++ b/src/main/java/seedu/duke/logic/parser/ParserUtils.java
@@ -65,7 +65,7 @@ public class ParserUtils {
                 isExerciseBank, isFoodBank, isRecurringExercise);
 
         if (!isItemSpecified) {
-            logger.log(Level.FINE, "Detected none or more than one item");
+            logger.log(Level.WARNING, "Detected none or more than one item");
             throw new ItemNotSpecifiedException();
         } else if (isExercise) {
             return Command.COMMAND_PREFIX_EXERCISE;
@@ -115,18 +115,18 @@ public class ParserUtils {
             String stringAfterPrefix = params.split(prefix + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String description = extractRelevantParameter(stringAfterPrefix);
             if (description.equals(ParserMessages.EMPTY)) {
-                logger.log(Level.FINE, "Detected empty description");
+                logger.log(Level.WARNING, "Detected empty description");
                 throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_NO_DESCRIPTION);
             }
             return description;
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, String.format("Detected missing command prefix (%s)", prefix));
+            logger.log(Level.WARNING, String.format("Detected missing command prefix (%s)", prefix));
             throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_DESCRIPTION);
         }
     }
 
 
-    protected static int extractItemCalories(String params, boolean isRequired)
+    protected static Integer extractItemCalories(String params, boolean isRequired)
             throws ParamInvalidException, ParamMissingException {
         try {
             if (params.contains(Command.COMMAND_PREFIX_CALORIES + Command.COMMAND_PREFIX_DELIMITER)) {
@@ -137,16 +137,16 @@ public class ParserUtils {
                 return Integer.parseInt(caloriesString);
             } else {
                 if (isRequired) {
-                    logger.log(Level.FINE, "Detected missing calories prefix");
+                    logger.log(Level.WARNING, "Detected missing calories prefix");
                     throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_CALORIES_INFO);
                 } else {
-                    logger.log(Level.FINE, "Detected missing calories prefix but calories not required, "
+                    logger.log(Level.WARNING, "Detected missing calories prefix but calories not required, "
                             + "returning null calorie value");
-                    return Command.NULL_CALORIES;
+                    return null;
                 }
             }
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit calories input");
+            logger.log(Level.WARNING, "Detected non-digit calories input");
             throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_INVALID_CALORIES_INFO);
         }
     }
@@ -158,17 +158,17 @@ public class ParserUtils {
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String name = extractRelevantParameter(stringAfterPrefix).trim();
             if (name.equals(ParserMessages.EMPTY)) {
-                logger.log(Level.FINE, "Detected empty name input.");
+                logger.log(Level.WARNING, "Detected empty name input.");
                 throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_NAME_EMPTY_STRING);
             }
             return name;
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing name prefix, returning empty string.");
-            return Command.NULL_STRING;
+            logger.log(Level.WARNING, "Detected missing name prefix, returning null string.");
+            return null;
         }
     }
 
-    protected static double extractHeight(String params) throws ParamInvalidException {
+    protected static Double extractHeight(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_HEIGHT
@@ -176,15 +176,15 @@ public class ParserUtils {
             String doubleString = stringAfterPrefix.split(" ", 2)[0];
             return Double.parseDouble(doubleString);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit height input.");
+            logger.log(Level.WARNING, "Detected non-digit height input.");
             throw new ParamInvalidException(String.format(ParserMessages.MESSAGE_ERROR_NOT_A_NUMBER, "height"));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing height prefix, return 0 height");
-            return Command.NULL_DOUBLE;
+            logger.log(Level.WARNING, "Detected missing height prefix, return null height");
+            return null;
         }
     }
 
-    protected static double extractWeight(String params) throws ParamInvalidException {
+    protected static Double extractWeight(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_WEIGHT
@@ -192,15 +192,15 @@ public class ParserUtils {
             String doubleString = stringAfterPrefix.split(" ", 2)[0];
             return Double.parseDouble(doubleString);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit weight input.");
+            logger.log(Level.WARNING, "Detected non-digit weight input.");
             throw new ParamInvalidException(String.format(ParserMessages.MESSAGE_ERROR_NOT_A_NUMBER, "weight"));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing weight prefix, return 0 weight");
-            return Command.NULL_DOUBLE;
+            logger.log(Level.WARNING, "Detected missing weight prefix, return null weight");
+            return null;
         }
     }
 
-    protected static int extractCalorieGoal(String params) throws ParamInvalidException {
+    protected static Integer extractCalorieGoal(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_GOAL
@@ -208,15 +208,15 @@ public class ParserUtils {
             String intString = stringAfterPrefix.split(" ", 2)[0];
             return Integer.parseInt(intString);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit goal input.");
+            logger.log(Level.WARNING, "Detected non-digit goal input.");
             throw new ParamInvalidException(String.format(ParserMessages.MESSAGE_ERROR_NOT_A_NUMBER, "goal"));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing goal prefix, return 0 goal");
-            return Command.NULL_INT;
+            logger.log(Level.WARNING, "Detected missing goal prefix, return 0 goal");
+            return null;
         }
     }
 
-    protected static int extractAge(String params) throws ParamInvalidException {
+    protected static Integer extractAge(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_AGE
@@ -224,15 +224,15 @@ public class ParserUtils {
             String intString = stringAfterPrefix.split(" ", 2)[0];
             return Integer.parseInt(intString);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit age input.");
+            logger.log(Level.WARNING, "Detected non-digit age input.");
             throw new ParamInvalidException(String.format(ParserMessages.MESSAGE_ERROR_NOT_A_NUMBER, "age"));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing age prefix, return 0 age");
-            return Command.NULL_INT;
+            logger.log(Level.WARNING, "Detected missing age prefix, return 0 age");
+            return null;
         }
     }
 
-    protected static int extractActivityFactor(String params) throws ParamInvalidException {
+    protected static Integer extractActivityFactor(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_ACTIVITY_FACTOR
@@ -240,23 +240,23 @@ public class ParserUtils {
             String intString = stringAfterPrefix.split(" ", 2)[0];
             return Integer.parseInt(intString);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit activity factor input.");
+            logger.log(Level.WARNING, "Detected non-digit activity factor input.");
             throw new ParamInvalidException(String.format(
                     ParserMessages.MESSAGE_ERROR_NOT_A_NUMBER, "activity factor"));
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing activity factor prefix, return 0 activity factor");
-            return Command.NULL_INT;
+            logger.log(Level.WARNING, "Detected missing activity factor prefix, return null activity factor");
+            return null;
         }
     }
 
-    protected static char extractGender(String params) throws ParamInvalidException {
+    protected static Character extractGender(String params) throws ParamInvalidException {
         try {
             String stringAfterPrefix =
                     params.split(Command.COMMAND_PREFIX_GENDER
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             return stringAfterPrefix.charAt(0);
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected missing gender prefix, return null gender");
+            logger.log(Level.WARNING, "Detected missing gender prefix, return null eqv gender");
             return Command.NULL_CHAR;
         }
     }
@@ -269,11 +269,11 @@ public class ParserUtils {
                     params.split(Command.COMMAND_PREFIX_START_DATE
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String dateString = extractRelevantParameter(stringAfterPrefix);
-            logger.log(Level.FINE, String.format("date string detected is: %s", dateString));
+            logger.log(Level.WARNING, String.format("date string detected is: %s", dateString));
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ParserMessages.DATE_FORMAT);
             return LocalDate.parse(dateString, formatter);
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected empty start date input after prefix but date is required!");
+            logger.log(Level.WARNING, "Detected empty start date input after prefix but date is required!");
             throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_START_DATE);
         } catch (DateTimeParseException e) {
             throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_INVALID_DATE_FORMAT);
@@ -288,11 +288,11 @@ public class ParserUtils {
                     params.split(Command.COMMAND_PREFIX_END_DATE
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String dateString = extractRelevantParameter(stringAfterPrefix);
-            logger.log(Level.FINE, String.format("date string detected is: %s", dateString));
+            logger.log(Level.WARNING, String.format("date string detected is: %s", dateString));
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ParserMessages.DATE_FORMAT);
             return LocalDate.parse(dateString, formatter);
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected empty end date input after prefix but date is required!");
+            logger.log(Level.WARNING, "Detected empty end date input after prefix but date is required!");
             throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_END_DATE);
         } catch (DateTimeParseException e) {
             throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_INVALID_DATE_FORMAT);
@@ -307,15 +307,15 @@ public class ParserUtils {
                     params.split(Command.COMMAND_PREFIX_DATE
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String dateString = extractRelevantParameter(stringAfterPrefix);
-            logger.log(Level.FINE, String.format("date string detected is: %s", dateString));
+            logger.log(Level.WARNING, String.format("date string detected is: %s", dateString));
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ParserMessages.DATE_FORMAT);
             return LocalDate.parse(dateString, formatter);
         } catch (IndexOutOfBoundsException e) {
             if (isRequired) {
-                logger.log(Level.FINE, "Detected empty date input after prefix but date is required!");
+                logger.log(Level.WARNING, "Detected empty date input after prefix but date is required!");
                 throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_DATE);
             } else {
-                logger.log(Level.FINE, "Detected empty date input after prefix, assuming date to be now");
+                logger.log(Level.WARNING, "Detected empty date input after prefix, assuming date to be now");
                 return LocalDate.now();
             }
         } catch (DateTimeParseException e) {
@@ -330,15 +330,15 @@ public class ParserUtils {
                     params.split(Command.COMMAND_PREFIX_TIME
                             + Command.COMMAND_PREFIX_DELIMITER, 2)[1];
             String timeString = extractRelevantParameter(stringAfterPrefix);
-            logger.log(Level.FINE, String.format("time string detected is: %s", timeString));
+            logger.log(Level.WARNING, String.format("time string detected is: %s", timeString));
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ParserMessages.TIME_FORMAT);
             return LocalTime.parse(timeString, formatter);
         } catch (IndexOutOfBoundsException e) {
             if (isRequired) {
-                logger.log(Level.FINE, "Detected empty time input after prefix but time is required!");
+                logger.log(Level.WARNING, "Detected empty time input after prefix but time is required!");
                 throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_TIME);
             } else {
-                logger.log(Level.FINE, "Detected empty time input after prefix, assuming time to be now");
+                logger.log(Level.WARNING, "Detected empty time input after prefix, assuming time to be now");
                 return LocalTime.now();
             }
         } catch (DateTimeParseException e) {
@@ -363,7 +363,7 @@ public class ParserUtils {
             String dateString = extractRelevantParameter(stringAfterPrefix);
             for (int i = 0; i < dateString.length(); i++) {
                 int day = Integer.parseInt(String.valueOf(dateString.charAt(i)));
-                logger.log(Level.FINE, String.format("day detected: %s", day));
+                logger.log(Level.WARNING, String.format("day detected: %s", day));
                 if (day >= ParserMessages.MONDAY && day <= ParserMessages.SUNDAY) { //between monday and sunday
                     if (dayOfTheWeek.contains(day)) {
                         throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_REPEATED_DAY_OF_THE_WEEK);
@@ -374,10 +374,10 @@ public class ParserUtils {
                 }
             }
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.FINE, "Detected empty day input after prefix but day is required!");
+            logger.log(Level.WARNING, "Detected empty day input after prefix but day is required!");
             throw new ParamMissingException(ParserMessages.MESSAGE_ERROR_NO_DAY_OF_THE_WEEK);
         } catch (NumberFormatException e) {
-            logger.log(Level.FINE, "Detected non-digit calories input");
+            logger.log(Level.WARNING, "Detected non-digit calories input");
             throw new ParamInvalidException(ParserMessages.MESSAGE_ERROR_INVALID_DAY_OF_THE_WEEK);
         }
         return dayOfTheWeek;
@@ -424,7 +424,7 @@ public class ParserUtils {
                 count++;
             }
         }
-        logger.log(Level.FINE, String.format("no. of corrected params detected: %s", count));
+        logger.log(Level.WARNING, String.format("no. of corrected params detected: %s", count));
         return count;
     }
 
@@ -442,7 +442,7 @@ public class ParserUtils {
                 numOfDelimiters++;
             }
         }
-        logger.log(Level.FINE, String.format("no. of delimiters detected: %s", numOfDelimiters));
+        logger.log(Level.WARNING, String.format("no. of delimiters detected: %s", numOfDelimiters));
         return numOfDelimiters > expectedNum;
     }
 }

--- a/src/main/java/seedu/duke/logic/parser/ParserUtils.java
+++ b/src/main/java/seedu/duke/logic/parser/ParserUtils.java
@@ -35,6 +35,7 @@ public class ParserUtils {
 
     /**
      * Extracts the item type prefix for command words that are common across item types (add, delete, view).
+     * //TODO: Item type must be the first word after the command word. E.g "add f/" is valid, "add potato f/" is not
      *
      * @param params String containing all parameters
      * @return String that is one of the item type prefixes
@@ -82,7 +83,6 @@ public class ParserUtils {
             return Command.COMMAND_PREFIX_FOOD_BANK;
         }
     }
-
 
     protected static boolean checkIsItemSpecified(boolean... paramBool) {
         int numberOfParams = 0;

--- a/src/main/java/seedu/duke/logic/parser/UpdateProfileParser.java
+++ b/src/main/java/seedu/duke/logic/parser/UpdateProfileParser.java
@@ -28,12 +28,12 @@ public class UpdateProfileParser implements Parser {
 
         try {
             final String name = ParserUtils.extractName(params);
-            final double height = ParserUtils.extractHeight(params);
-            final double weight = ParserUtils.extractWeight(params);
-            final int calorieGoal = ParserUtils.extractCalorieGoal(params);
-            final int age = ParserUtils.extractAge(params);
-            final int activityFactor = ParserUtils.extractActivityFactor(params);
-            final char gender = ParserUtils.extractGender(params);
+            final Double height = ParserUtils.extractHeight(params);
+            final Double weight = ParserUtils.extractWeight(params);
+            final Integer calorieGoal = ParserUtils.extractCalorieGoal(params);
+            final Integer age = ParserUtils.extractAge(params);
+            final Integer activityFactor = ParserUtils.extractActivityFactor(params);
+            final Character gender = ParserUtils.extractGender(params);
             return new ProfileUpdateCommand(name, height, weight, calorieGoal, age, activityFactor, gender);
         } catch (ParamInvalidException e) {
             return new InvalidCommand(e.getMessage());

--- a/src/main/java/seedu/duke/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/duke/logic/parser/ViewCommandParser.java
@@ -18,17 +18,16 @@ public class ViewCommandParser implements Parser {
     @Override
     public Command parse(String params) {
         try {
-            final String itemTypePrefix = ParserUtils.extractItemTypePrefix(params);
-            switch (itemTypePrefix) {
-            case Command.COMMAND_PREFIX_EXERCISE:
+            switch (params) {
+            case Command.COMMAND_PREFIX_EXERCISE + Command.COMMAND_PREFIX_DELIMITER:
                 return new ViewExerciseListCommand();
-            case Command.COMMAND_PREFIX_FOOD:
+            case Command.COMMAND_PREFIX_FOOD + Command.COMMAND_PREFIX_DELIMITER:
                 return new ViewFoodListCommand();
-            case Command.COMMAND_PREFIX_UPCOMING_EXERCISE:
+            case Command.COMMAND_PREFIX_UPCOMING_EXERCISE + Command.COMMAND_PREFIX_DELIMITER:
                 return new ViewFutureExerciseListCommand();
-            case Command.COMMAND_PREFIX_EXERCISE_BANK:
+            case Command.COMMAND_PREFIX_EXERCISE_BANK + Command.COMMAND_PREFIX_DELIMITER:
                 return new ViewExerciseBankCommand();
-            case Command.COMMAND_PREFIX_FOOD_BANK:
+            case Command.COMMAND_PREFIX_FOOD_BANK + Command.COMMAND_PREFIX_DELIMITER:
                 return new ViewFoodBankCommand();
             default:
                 throw new ItemNotSpecifiedException();

--- a/src/test/java/seedu/duke/data/profile/attributes/HeightTest.java
+++ b/src/test/java/seedu/duke/data/profile/attributes/HeightTest.java
@@ -9,8 +9,8 @@ class HeightTest {
 
     @Test
     void createHeight_validHeightInputs_expectTrue() {
-        final Height h1 = new Height(190);
-        final Height h2 = new Height(165);
+        final Height h1 = new Height(190.0);
+        final Height h2 = new Height(165.0);
         assertTrue(h1.isValid());
         assertTrue(h2.isValid());
     }


### PR DESCRIPTION
- Make parsing of optional parameters less bug-prone
- `view` command now requires exact string match for item type, e.g `view f///////` not allowed anymore 

Fixes #159 